### PR TITLE
Unviable pokemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ const ohbem = new Ohbem({
     pokemonData,
     // If you have installed lru-cache, uncomment the following to use caching:
     // cachingStrategy: Ohbem.cachingStrategies.balanced,
+    // Ohbem's default setting is to remove Pokemon who do not not reach the league CP cap at a given level
+    // cap even with 15/15/15 stats. This can be turned off by uncommenting this line
+    // removeUnviablePokemon: false,
 });
 ohbem.queryPvPRank(
     /* pokemonId: */    605,

--- a/index.js
+++ b/index.js
@@ -227,7 +227,7 @@ class Ohbem {
             little: name.startsWith("little"),
         };
         this._levelCaps = options.levelCaps || [50, 51];
-        this._removeUnviablePokemon = options.removeUnviablePokemon || true;
+        this._removeUnviablePokemon = options.removeUnviablePokemon ?? true;
         this._pokemonData = options.pokemonData;
         if (options.cachingStrategy) [this._rankCache, this._compactCache] = options.cachingStrategy(); else {
             this._rankCache = null;

--- a/index.js
+++ b/index.js
@@ -212,6 +212,8 @@ class Ohbem {
      * @param {Function} [options.cachingStrategy] An optional function constructing a cache
      *  implementing get(key) and set(key, value), along with a boolean for whether compact mode (#3) should be used.
      *  @see cachingStrategies
+     * @param {boolean} [options.removeUnviablePokemon] A boolean representing whether Ohbem will remove Pokemon
+     *  who do not reach league CP cap at Level Cap even with 15/15/15 stats [default: true]
      */
     constructor(options = {}) {
         this._leagues = {};
@@ -225,6 +227,7 @@ class Ohbem {
             little: name.startsWith("little"),
         };
         this._levelCaps = options.levelCaps || [50, 51];
+        this._removeUnviablePokemon = options.removeUnviablePokemon || true;
         this._pokemonData = options.pokemonData;
         if (options.cachingStrategy) [this._rankCache, this._compactCache] = options.cachingStrategy(); else {
             this._rankCache = null;
@@ -258,7 +261,7 @@ class Ohbem {
                 return result;
             } : (lvCap) => calculateRanks(stats, cpCap, lvCap).combinations;
             for (const lvCap of this._levelCaps) {
-                //if (calculateCp(stats, 15, 15, 15, lvCap) <= cpCap) continue;   // not viable
+                if (this._removeUnviablePokemon && calculateCp(stats, 15, 15, 15, lvCap) <= cpCap) continue;   // not viable
                 if (combinationIndex === null) combinationIndex = { [lvCap]: calculator(lvCap) };
                 else combinationIndex[lvCap] = calculator(lvCap);
                 // check if no more power up is possible: further increasing the cap will not be relevant
@@ -323,7 +326,7 @@ class Ohbem {
                 }
                 let maxed = false;
                 for (const cap of this._levelCaps) {
-                    //if (calculateCp(stats, 15, 15, 15, cap) <= leagueOptions.cap) continue;
+                    if (this._removeUnviablePokemon && calculateCp(stats, 15, 15, 15, cap) <= leagueOptions.cap) continue;
                     processLevelCap(cap);
                     if (calculateCp(stats, ivFloor, ivFloor, ivFloor, cap + .5) > leagueOptions.cap) {
                         maxed = true;

--- a/index.js
+++ b/index.js
@@ -258,7 +258,7 @@ class Ohbem {
                 return result;
             } : (lvCap) => calculateRanks(stats, cpCap, lvCap).combinations;
             for (const lvCap of this._levelCaps) {
-                if (calculateCp(stats, 15, 15, 15, lvCap) <= cpCap) continue;   // not viable
+                //if (calculateCp(stats, 15, 15, 15, lvCap) <= cpCap) continue;   // not viable
                 if (combinationIndex === null) combinationIndex = { [lvCap]: calculator(lvCap) };
                 else combinationIndex[lvCap] = calculator(lvCap);
                 // check if no more power up is possible: further increasing the cap will not be relevant
@@ -323,7 +323,7 @@ class Ohbem {
                 }
                 let maxed = false;
                 for (const cap of this._levelCaps) {
-                    if (calculateCp(stats, 15, 15, 15, cap) <= leagueOptions.cap) continue;
+                    //if (calculateCp(stats, 15, 15, 15, cap) <= leagueOptions.cap) continue;
                     processLevelCap(cap);
                     if (calculateCp(stats, ivFloor, ivFloor, ivFloor, cap + .5) > leagueOptions.cap) {
                         maxed = true;


### PR DESCRIPTION
Ohbem's design has it removing Pokemon who do not not reach the league CP cap by the time they reach the level cap even with 15/15/15 stats. 

This gives rise to confusion around a pokemon's ranking and inconsistency with other calculators.

This change allows this behaviour to be turned off by setting the new `removeUnviablePokemon` setting to 'true'. The default is to maintain current behaviour.

