### PR TITLE
Break ranking ties in case of having different attack stats

### DIFF
--- a/index.js
+++ b/index.js
@@ -235,6 +235,7 @@ class Ohbem {
      *  implementing get(key) and set(key, value), along with a boolean for whether compact mode (#3) should be used.
      *  @see cachingStrategies
      * @param {Function} [options.rankingComparator] An optional function determining how everything should be ranked.
+     *  @see rankingComparators.default
      */
     constructor(options = {}) {
         this._leagues = {};

--- a/index.js
+++ b/index.js
@@ -408,6 +408,7 @@ class Ohbem {
                                 percentage: Number((stat.value / combinations[4096]).toFixed(5)),
                                 rank: combinations[(attack * 16 + defense) * 16 + stamina],
                             };
+                            delete entry.attack;
                         } else {
                             const ivEntry = combinations[attack][defense][stamina];
                             if (level > ivEntry.level) continue;

--- a/test/pvp-core.js
+++ b/test/pvp-core.js
@@ -22,9 +22,11 @@ describe('PvP Core', () => {
     });
     it('calculateRanks', async () => {
         const { pokemon } = await pokemonData;
-        const getRank = (stats, cpCap, lvCap, a, d, s, compact) => {
-            if (compact) return calculateRanksCompact(stats, cpCap, lvCap).combinations[(a * 16 + d) * 16 + s];
-            return calculateRanks(stats, cpCap, lvCap).combinations[a][d][s].rank;
+        const getRank = (stats, cpCap, lvCap, a, d, s, compact, comparator = Ohbem.rankingComparators.default) => {
+            if (compact) {
+                return calculateRanksCompact(stats, cpCap, lvCap, comparator).combinations[(a * 16 + d) * 16 + s];
+            }
+            return calculateRanks(stats, cpCap, lvCap, comparator).combinations[a][d][s].rank;
         }
         for (const compact of [false, true]) {
             assert.strictEqual(getRank(pokemon[26], 1500, 40, 15, 15, 15, compact), 742,
@@ -35,6 +37,22 @@ describe('PvP Core', () => {
                 `Tied Golem rank 4A [${compact}]`);
             assert.strictEqual(getRank(pokemon[76], 1500, 50, 1, 15, 14, compact), 4,
                 `Tied Golem rank 4B [${compact}]`);
+            assert.strictEqual(getRank(pokemon[227], 1500, 50, 0, 15, 14, compact), 1,
+                `Rank 1 higher CP Skarmory default comparator [${compact}]`);
+            assert.strictEqual(getRank(pokemon[227], 1500, 50, 0, 15, 13, compact), 1,
+                `Rank 1 lower CP Skarmory default comparator [${compact}]`);
+            assert.strictEqual(getRank(pokemon[227], 1500, 50, 0, 15, 14, compact,
+                    Ohbem.rankingComparators.preferHigherCp), 1,
+                `Rank 1 higher CP Skarmory preferHigherCp comparator [${compact}]`);
+            assert.strictEqual(getRank(pokemon[227], 1500, 50, 0, 15, 13, compact,
+                    Ohbem.rankingComparators.preferHigherCp), 2,
+                `Rank 1 lower CP Skarmory preferHigherCp comparator [${compact}]`);
+            assert.strictEqual(getRank(pokemon[227], 1500, 50, 0, 15, 14, compact,
+                    Ohbem.rankingComparators.preferLowerCp), 2,
+                `Rank 1 higher CP Skarmory preferLowerCp comparator [${compact}]`);
+            assert.strictEqual(getRank(pokemon[227], 1500, 50, 0, 15, 13, compact,
+                    Ohbem.rankingComparators.preferLowerCp), 1,
+                `Rank 1 lower CP Skarmory preferLowerCp comparator [${compact}]`);
             assert.strictEqual(getRank(pokemon[351], 1500, 51, 4, 14, 15, compact), 56,
                 `Weather boosted Castform rank [${compact}]`);
             assert.strictEqual(getRank(pokemon[660], 1500, 100, 0, 15, 11, compact), 1,

--- a/test/pvp-core.js
+++ b/test/pvp-core.js
@@ -29,6 +29,12 @@ describe('PvP Core', () => {
         for (const compact of [false, true]) {
             assert.strictEqual(getRank(pokemon[26], 1500, 40, 15, 15, 15, compact), 742,
                 `Hundo Raichu rank [${compact}]`);
+            assert.strictEqual(getRank(pokemon[76], 1500, 50, 2, 14, 13, compact), 3,
+                `Tied Golem rank 3 [${compact}]`);
+            assert.strictEqual(getRank(pokemon[76], 1500, 50, 1, 15, 13, compact), 4,
+                `Tied Golem rank 4A [${compact}]`);
+            assert.strictEqual(getRank(pokemon[76], 1500, 50, 1, 15, 14, compact), 4,
+                `Tied Golem rank 4B [${compact}]`);
             assert.strictEqual(getRank(pokemon[351], 1500, 51, 4, 14, 15, compact), 56,
                 `Weather boosted Castform rank [${compact}]`);
             assert.strictEqual(getRank(pokemon[660], 1500, 100, 0, 15, 11, compact), 1,


### PR DESCRIPTION
Attack stats determine CMP ties. Fixes #15.

Added test cases for Golem 2/14/13, 1/15/13, and 1/15/14.

Old behavior: Giving rank 3 for all three combinations.
New behavior: 2/14/13 is rank 3 as it has higher attack, and the other two are tied rank 4.

Explore the full IV table for this test case here: https://codepen.io/Mygod/full/qBRGbBo?stats=211/198/190

Related discussions: https://github.com/Pupitar/ohbemgo/issues/9#issuecomment-1491019550

This should not affect any rank 1 and rank 2 calculations that currently exist.